### PR TITLE
[Task] Use Image URI generated by ImageService for non-processed files

### DIFF
--- a/Classes/ViewHelpers/ResponsiveImageViewHelper.php
+++ b/Classes/ViewHelpers/ResponsiveImageViewHelper.php
@@ -193,10 +193,12 @@ class ResponsiveImageViewHelper extends ImageViewHelper
             $this->tag->addAttribute('src', 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==');
             $this->tag->addAttribute('data-srcset', $dataSrcset);
         } else {
-            $src = $image->getOriginalFile()->getPublicUrl();
-            // Force absolute web path:
-            $src = strpos($src, '/') == 0 ?: '/' . $src;
-            $this->tag->addAttribute('src', $src);
+            if ($typo3Version >= 7006000) {
+                $imageUri = $this->imageService->getImageUri($image, $this->arguments['absolute']);
+            } else {
+                $imageUri = $this->imageService->getImageUri($image);
+            }
+            $this->tag->addAttribute('src', $imageUri);
             $this->tag->addAttribute('class', 'xm-responsive-images xm-responsive-images--excluded');
         }
 


### PR DESCRIPTION
If there are non-processed files (e.g. gifs) recently the URI of the image was absolute. This works on systems, where the filedamin can be found in the root. If that's not the case, the images cannot be loaded in the frontend.

This change fixes this behaviour, so the relative path is used.