### PR TITLE
feat: remove php-composer-reader dependency

### DIFF
--- a/Classes/Backend/ToolbarItems/WebsiteVersionToolbarItem.php
+++ b/Classes/Backend/ToolbarItems/WebsiteVersionToolbarItem.php
@@ -3,11 +3,10 @@
 
 namespace Xima\XmTools\Backend\ToolbarItems;
 
-
-use Nadar\PhpComposerReader\ComposerReader;
 use TYPO3\CMS\Backend\Toolbar\ToolbarItemInterface;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Package\PackageManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Fluid\View\StandaloneView;
 
@@ -49,7 +48,7 @@ class WebsiteVersionToolbarItem implements ToolbarItemInterface
      */
     protected function getWebsiteVersion(): string
     {
-        return (new ComposerReader(Environment::getProjectPath() . '/composer.json'))->contentSection('version', '');
+        return (GeneralUtility::makeInstance(PackageManager::class)->getComposerManifest(Environment::getProjectPath() . '/', true))->version;
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
   "require": {
     "php": "^7.4 || ^8.0",
     "typo3/cms-core": "11.5.*",
-    "typo3/cms-extensionmanager": "11.5.*",
-    "nadar/php-composer-reader": "^1.3"
+    "typo3/cms-extensionmanager": "11.5.*"
   },
   "require-dev": {
     "typo3/testing-framework": "^6.4.6"


### PR DESCRIPTION
package nadar/php-composer-reader has outdated dependencies and gets superfluous with a simple code change.